### PR TITLE
Org rename

### DIFF
--- a/main.py
+++ b/main.py
@@ -188,7 +188,9 @@ def get_args():
     args = parser.parse_args()
 
     if not args.travis_token:
-        sys.exit("Argument --travis-key or environment variable TRAVIS_KEY must be set")
+        sys.exit(
+            "Argument --travis-token or environment variable TRAVIS_TOKEN must be set"
+        )
     if not args.local_only:
         if not args.s3_access_key:
             sys.exit(

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ import requests
 def main():
     args = get_args()
 
-    repo_slug = quote_plus("open-cluster-management/governance-policy-framework")
+    repo_slug = quote_plus(args.repo)
     repo_url = f"https://api.travis-ci.com/repo/{repo_slug}"
     ids = get_new_build_ids(
         repo_url,
@@ -120,6 +120,11 @@ def get_args():
         required=True,
         type=int,
         help="Travis build id (not repo-specific) of the last known build",
+    )
+    parser.add_argument(
+        "--repo",
+        default="stolostron/governance-policy-framework",
+        help="Github repository (in org/repo format) of the Travis builds to analyze",
     )
     parser.add_argument(
         "--out-file",


### PR DESCRIPTION
The pipeline is failing to get the Travis builds, since the org rename. This should fix it in an easily adjustable way for the future (both org and repo could be adjusted in the configuration).

Also fixes an incorrect error message I found when running locally.